### PR TITLE
ViewManagerクラスを追加

### DIFF
--- a/ImageTracer/ImageTracer.csproj
+++ b/ImageTracer/ImageTracer.csproj
@@ -136,13 +136,14 @@
     </Compile>
     <Compile Include="ViewModels\KeySettingDialogViewModel.cs" />
     <Compile Include="ViewModels\ViewModelBase.cs" />
-    <Compile Include="ViewModels\ViewModelStaticContainer.cs" />
+    <Compile Include="ViewModels\ViewModelManager.cs" />
     <Compile Include="Views\KeySettingDialog.xaml.cs">
       <DependentUpon>KeySettingDialog.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\SettingDialog.xaml.cs">
       <DependentUpon>SettingDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\ViewManager.cs" />
     <Compile Include="Views\WindowServices.cs" />
     <Page Include="ResourceDictionaries\RootDictionary.xaml">
       <SubType>Designer</SubType>

--- a/ImageTracer/SystemTray/NotifyIconWrapper.cs
+++ b/ImageTracer/SystemTray/NotifyIconWrapper.cs
@@ -14,8 +14,6 @@ namespace ImageTracer.SystemTray
 {
     public partial class NotifyIconWrapper : Component
     {
-        public static NotifyIconWrapper Instance = null;
-
         public NotifyIconWrapper()
         {
             InitializeComponent();
@@ -24,10 +22,8 @@ namespace ImageTracer.SystemTray
             this.settingMenuItem.Click += OnSettingMenuItemClick;
             this.quitMenuItem.Click += OnQuitMenuItemClick;
 
-            ShowMainWindow();
+            ViewManager.RequestShowMainWindow();
             ShowBalloonTip();
-
-            Instance = this;
         }
 
         public NotifyIconWrapper(IContainer container)
@@ -39,68 +35,17 @@ namespace ImageTracer.SystemTray
 
         private void OnShowMenuItemClick(object sender, EventArgs e)
         {
-            ShowMainWindow();
+            ViewManager.RequestShowMainWindow();
         }
 
         private void OnSettingMenuItemClick(object sender, EventArgs e)
         {
-            ShowSettingDialog();
+            ViewManager.RequestShowSettingDialog();
         }
 
         private void OnQuitMenuItemClick(object sender, EventArgs e)
         {
             Application.Current.Shutdown(0);
-        }
-
-        /// <summary>
-        /// メイン画面が表示されていない場合は表示する。
-        /// </summary>
-        private void ShowMainWindow()
-        {
-            // メイン画面が表示されていない場合
-            if (!_isMainWindowVisible)
-            {
-                _mainWindow = new MainWindow();
-                _mainWindow.ContentRendered += (sd, ev) =>
-                {
-                    _isMainWindowVisible = true;
-                };
-                _mainWindow.Closed += (sd, ev) =>
-                {
-                    _isMainWindowVisible = false;
-                };
-
-                // メイン画面を表示する。
-                _mainWindow.Show();
-            }
-        }
-
-        /// <summary>
-        /// 設定画面が表示されていない場合は表示する。
-        /// </summary>
-        public void ShowSettingDialog()
-        {
-            // メイン画面が表示されていない場合は表示する。
-            ShowMainWindow();
-
-            // 設定画面が表示されていない場合
-            if (!_isSettingDialogVisible)
-            {
-                SettingDialog settingDialog = new SettingDialog(ViewModelStaticContainer.MainWindowViewModel);
-                settingDialog.Owner = _mainWindow;
-
-                settingDialog.ContentRendered += (sd, ev) =>
-                {
-                    _isSettingDialogVisible = true;
-                };
-                settingDialog.Closed += (sd, ev) =>
-                {
-                    _isSettingDialogVisible = false;
-                };
-
-                // 設定画面を表示する。
-                settingDialog.Show();
-            }
         }
 
         private void ShowBalloonTip()
@@ -113,14 +58,5 @@ namespace ImageTracer.SystemTray
                 Properties.Settings.Default.Save();
             }
         }
-
-        /// <summary>
-        /// メイン画面。
-        /// 半透明画像を表示するための "枠なし、背景透明" のウィンドウ。
-        /// </summary>
-        private MainWindow _mainWindow = null;
-
-        private bool _isMainWindowVisible = false;
-        private bool _isSettingDialogVisible = false;
     }
 }

--- a/ImageTracer/ViewModels/MainWindowViewModel.cs
+++ b/ImageTracer/ViewModels/MainWindowViewModel.cs
@@ -380,7 +380,7 @@ namespace ImageTracer.ViewModels
             if (_settingDialogTransitionMessage != null) return;
 
             // 設定画面を表示する。
-            NotifyIconWrapper.Instance.ShowSettingDialog();
+            ViewManager.RequestShowSettingDialog();
         }
         #endregion
 

--- a/ImageTracer/ViewModels/ViewModelManager.cs
+++ b/ImageTracer/ViewModels/ViewModelManager.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace ImageTracer.ViewModels
 {
-    public static class ViewModelStaticContainer
+    public static class ViewModelManager
     {
         public static MainWindowViewModel MainWindowViewModel = new MainWindowViewModel();
     }

--- a/ImageTracer/Views/MainWindow.xaml.cs
+++ b/ImageTracer/Views/MainWindow.xaml.cs
@@ -43,7 +43,7 @@ namespace ImageTracer.Views
         {
             InitializeComponent();
 
-            _vm = ViewModelStaticContainer.MainWindowViewModel;
+            _vm = ViewModelManager.MainWindowViewModel;
             _vm.ThroughHitChanged += OnThroughHitChanged;
             _vm.FixRateCommand.ExecuteHandler = FixRateCommandExecute;
             _vm.FixRateCommand.CanExecuteHandler = CanFixRateCommandExecute;
@@ -390,7 +390,7 @@ namespace ImageTracer.Views
                 Key key = KeyInterop.KeyFromVirtualKey(keyCode);
 
                 // VMのコマンドを実行する。
-                ViewModelStaticContainer.MainWindowViewModel.KeyInputCommand.Execute(key);
+                ViewModelManager.MainWindowViewModel.KeyInputCommand.Execute(key);
             }
 
             // キーボードのイベントに紐付けられた次のメソッドを実行する。メソッドがなければ処理終了。

--- a/ImageTracer/Views/SettingDialog.xaml.cs
+++ b/ImageTracer/Views/SettingDialog.xaml.cs
@@ -21,25 +21,19 @@ namespace ImageTracer.Views
     /// </summary>
     public partial class SettingDialog : Window
     {
+        private MainWindowViewModel _vm = null;
+
         public SettingDialog()
         {
             InitializeComponent();
-        }
 
-        public SettingDialog(MainWindowViewModel vm)
-        {
-            if (vm == null)
-            {
-                throw new ArgumentNullException("vm");
-            }
-
-            InitializeComponent();
-            this.DataContext = vm;
+            _vm = ViewModelManager.MainWindowViewModel;
+            this.DataContext = _vm;
         }
 
         private void _settingDialog_Closed(object sender, EventArgs e)
         {
-            ViewModelStaticContainer.MainWindowViewModel.SettingDialogTransitionMessage = null;
+            ViewModelManager.MainWindowViewModel.SettingDialogTransitionMessage = null;
         }
     }
 }

--- a/ImageTracer/Views/ViewManager.cs
+++ b/ImageTracer/Views/ViewManager.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ImageTracer.Views
+{
+    public static class ViewManager
+    {
+        /// <summary>
+        /// メイン画面が表示されていない場合は表示する。
+        /// </summary>
+        public static void RequestShowMainWindow()
+        {
+            // メイン画面が表示されていない場合
+            if (!_isMainWindowVisible)
+            {
+                _mainWindow = new MainWindow();
+                _mainWindow.ContentRendered += (sd, ev) =>
+                {
+                    _isMainWindowVisible = true;
+                };
+                _mainWindow.Closed += (sd, ev) =>
+                {
+                    _isMainWindowVisible = false;
+                };
+
+                // メイン画面を表示する。
+                _mainWindow.Show();
+            }
+        }
+
+        /// <summary>
+        /// 設定画面が表示されていない場合は表示する。
+        /// </summary>
+        public static void RequestShowSettingDialog()
+        {
+            // メイン画面が表示されていない場合は表示する。
+            RequestShowMainWindow();
+
+            // 設定画面が表示されていない場合
+            if (!_isSettingDialogVisible)
+            {
+                SettingDialog settingDialog = new SettingDialog();
+                settingDialog.Owner = _mainWindow;
+
+                settingDialog.ContentRendered += (sd, ev) =>
+                {
+                    _isSettingDialogVisible = true;
+                };
+                settingDialog.Closed += (sd, ev) =>
+                {
+                    _isSettingDialogVisible = false;
+                };
+
+                // 設定画面を表示する。
+                settingDialog.Show();
+            }
+        }
+
+        /// <summary>
+        /// メイン画面。
+        /// 半透明画像を表示するための "枠なし、背景透明" のウィンドウ。
+        /// </summary>
+        private static MainWindow _mainWindow = null;
+
+        private static bool _isMainWindowVisible = false;
+        private static bool _isSettingDialogVisible = false;
+    }
+}


### PR DESCRIPTION
画面表示処理をすべてViewManagerクラスに移譲した。
命名の統一のため、ViewModelStaticContainerクラスの名前をViewModelManagerに変更した。
close #29 